### PR TITLE
upkeep/6 Bump PHP "tested up to" version 8.3

### DIFF
--- a/includes/class-wc-gateway-converge.php
+++ b/includes/class-wc-gateway-converge.php
@@ -22,6 +22,11 @@ class WC_Gateway_Converge extends WC_Payment_Gateway_CC {
 	private $converge_order_wrapper;
 
 	/**
+	 * @var League\ISO3166\ISO3166
+	 */
+	private $isoConvertor;
+
+	/**
 	 * Encryption class
 	 *
 	 * @var \Elavon\Converge2\Util\Encryption

--- a/includes/functions-wc-gateway-converge.php
+++ b/includes/functions-wc-gateway-converge.php
@@ -991,7 +991,7 @@ function wgc_conditional_payment_gateways( $available_gateways ) {
 
 	if ( wgc_order_from_merchant_view_has_subscription_elements() ) {
 		$hide_other_methods = true;
-	} else {
+	} else if ( WC()->cart ) {
 		foreach ( WC()->cart->get_cart() as $cart_key => $cart_item ) {
 			if ( wgc_product_is_subscription( $cart_item['data'] ) ) {
 				$hide_other_methods = true;

--- a/includes/subscriptions/class-wc-cart-converge-subscriptions.php
+++ b/includes/subscriptions/class-wc-cart-converge-subscriptions.php
@@ -7,7 +7,12 @@ class WC_Cart_Converge_Subscriptions {
 	 * @var bool
 	 */
 	private $wgc_recurring_total_calculation = false;
-	
+
+	/**
+	 * @var string
+	 */
+	private $current_recurring_cart_key = '';
+
 	public function __construct() {
 		add_filter( 'woocommerce_add_to_cart_handler', array( $this, 'add_to_cart_handler' ), 10, 2 );
 		add_filter( 'woocommerce_cart_product_price', array( $this, 'cart_product_price' ), 10, 2 );


### PR DESCRIPTION
This PR simply includes a note regarding the "PHP tested up to: 8.3". While this information may not have direct utility for WordPress/WP.org, it is an internally decided retaining it would be nice to have.

The following steps are tested in the PHP 8.3 environment.

- ✅ Simple product order placement with Elavon Converge EU Gateway
- ✅ Subscription order placement
- ✅ Variable Subscription order placement
- ✅ Subscription status can be updated
- ✅ Subscription list in backend and front end sides
- ✅ Subscription listed on the order successfull page, edit order page, my accounts > converge subscription page
- ✅ Card can be saved for later use
- ✅ Saved Card can be edited
- ✅ Saved Card can be removed if no subscriptions are active and linked with it

The following warnings(s) were noticed and fixed. ✅

```
PHP Fatal error:  Uncaught Error: Call to a member function get_cart() on null in /Users/faisalalvi/LocalSites/wpne/app/public/wp-content/plugins/woocommerce-gateway-converge/includes/functions-wc-gateway-converge.php:995

Creation of dynamic property WC_Gateway_Converge::$isoConvertor is deprecated

Creation of dynamic property WC_Cart_Converge_Subscriptions::$current_recurring_cart_key is deprecated
```

While performing the test, the following warnings were reported that were coming from the ./vendor folder and these need to be fixed at upstream (i.e. in `converge2-php-sdk` repo). ⚠️

```
Deprecated	Return type of Elavon\Converge2\DataObject\AbstractEnum::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice	
wp-content/plugins/woocommerce-gateway-converge/vendor/elavon/converge2-php-sdk/src/DataObject/AbstractEnum.php:17

Deprecated	Return type of Elavon\Converge2\DataObject\AbstractDataObject::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice	
wp-content/plugins/woocommerce-gateway-converge/vendor/elavon/converge2-php-sdk/src/DataObject/AbstractDataObject.php:18

```

Make sure the plugin works fine in the PHP 8.3 environment and there are 0 errors/warnings reported in the error logs while/after performing the test steps mentioned above.

> Tweak - Bump PHP "tested up to" version 8.3.