### PR TITLE
Bump "tested up to" WordPress 6.4

### DIFF
--- a/woocommerce-gateway-converge.php
+++ b/woocommerce-gateway-converge.php
@@ -21,6 +21,8 @@
  * Author URI:        http://www.elavon.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Tested up to:      6.4
+ * Requires at least: 6.3
  * Text Domain:       elavon-converge-gateway
  * Domain Path:       /languages
  */


### PR DESCRIPTION
* Bump WordPress Tested up to version 6.4
* Bump WordPress Requires at least 6.3

Closes #4

> Dev - Bump WordPress "tested up to" version 6.4.
> Dev - Bump WordPress minimum supported version to 6.3.